### PR TITLE
HFIX: Fix occasions where snap.yaml does not exist.

### DIFF
--- a/lib/spicetify-builder.nix
+++ b/lib/spicetify-builder.nix
@@ -121,6 +121,8 @@ in
       }
       popd > /dev/null
       ${spicetifyCmd} backup apply
-      rm $out/snap.yaml
+      if [ -f $out/snap.yaml ]; then
+        rm $out/snap.yaml
+      fi 
     '';
   })


### PR DESCRIPTION
error: builder for '/nix/store/6jkq7ny1m7qv8z1fszv8vs9wvmgzxcsc-spicetify-text.drv' failed with exit code 1;
       last 10 log lines:
       > Transferring extensions:
       > success 05:33:16 All extensions are updated.
       > OK
       > Transferring custom apps:
       > OK
       > Patching:
       > success xpui.js_find_8008 is patched
       > OK
       > success Spotify is spiced up!
       > rm: cannot remove '/nix/store/cv3l4b6hbwrr9a2x27jhlba1sa1h83pr-spicetify-text/snap.yaml': No such file or directory
       For full logs, run 'nix log /nix/store/6jkq7ny1m7qv8z1fszv8vs9wvmgzxcsc-spicetify-text.drv'.